### PR TITLE
withTemplates bug fix

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -49,7 +49,7 @@ func withTemplates(fsys fs.FS, dirPath, fileSuffix string) (map[string]string, e
 			if err != nil {
 				return rootTemplates, err
 			}
-			stripedFileName := strings.TrimRight(file.Name(), fileSuffix)
+			stripedFileName := strings.TrimSuffix(file.Name(), fileSuffix)
 			rootTemplates[stripedFileName] = string(data)
 		}
 	}


### PR DESCRIPTION
Found an issue with TrimRight removing extra characters from the end of template names. 
This would cause a `template not found error`  when sending slack messages.

Changed `TrimRight -> TrimSuffix` in `withTemplates()`