### PR TITLE
use-text-template

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -4,10 +4,10 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"html/template"
 	"io/fs"
 	"path/filepath"
 	"strings"
+	"text/template"
 )
 
 func parse(templateName string, templateMap map[string]string, data any) ([]byte, error) {


### PR DESCRIPTION
For slack, this is double encoding the output templates. This is very visbile in dates

html/template: 2022-11-21T09:45:46&#43;11:00
text/template:  2022-11-21T09:47:44+11:00